### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/functions/battery.fish
+++ b/functions/battery.fish
@@ -5,7 +5,7 @@
 #   OS X and Linux compatible battery utility.
 #
 # USAGE
-#   if available battery
+#   if type -q battery
 #     battery
 #   end
 #

--- a/functions/battery.info.update.linux.fish
+++ b/functions/battery.info.update.linux.fish
@@ -1,5 +1,5 @@
 function battery.info.update.linux
-  if not available upower
+  if not type -q upower
     echo "Please install upower"
     return 1
   end


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
