### PR TITLE
Fix 'unexpected token' error when BATTERY_PCT empty

### DIFF
--- a/functions/battery.info.update.linux.fish
+++ b/functions/battery.info.update.linux.fish
@@ -25,5 +25,9 @@ function battery.info.update.linux
   | grep "time to" \
   | cut -d":" -f 2)
 
-  set -g BATTERY_SLOTS (math $BATTERY_PCT / 10)
+  if test "$BATTERY_PCT" != ""
+      set -g BATTERY_SLOTS (math $BATTERY_PCT / 10)
+  else
+      set -g BATTERY_SLOTS 1
+  end
 end


### PR DESCRIPTION
Was getting the following error when fish started up:

```
math: Error: Unexpected token
'/ 10'
```

Added an if statement to check that the `BATTERY_PCT` variable wasn't empty before trying to use it to do division fixed the problem.